### PR TITLE
Metabox Wrap Fix

### DIFF
--- a/google-calendar-events/css/admin.css
+++ b/google-calendar-events/css/admin.css
@@ -50,3 +50,7 @@
 	color: #8a6d3b;
 	padding: 15px;
 }
+
+#gce_feed_meta .inside code {
+	word-break: break-all;
+}


### PR DESCRIPTION
Allows `<code>` tags to wrap at any character, preventing them from
overrunning the metabox container.
