### PR TITLE
Use month and year for previous and next links

### DIFF
--- a/google-calendar-events/css/gce-style.css
+++ b/google-calendar-events/css/gce-style.css
@@ -12,6 +12,8 @@
 .gce-page-grid .gce-calendar .gce-caption{ /* Caption at top of calendar */
 	color:#333333;
 	text-align:center;
+	padding-bottom:10px;
+	position:relative;
 }
 
 .gce-page-grid .gce-calendar{ /* Main calendar table */
@@ -56,18 +58,20 @@
 .gce-page-grid .gce-calendar .gce-next,
 .gce-page-grid .gce-calendar .gce-prev{ /* Previous and next month links */
 	cursor:pointer;
-	display:inline-block;
-	width:5%;
-	white-space: nowrap;
 }
 
 .gce-page-grid .gce-calendar .gce-prev{
-	float: left;
+	left:0;
+	position:absolute;
+}
+
+.gce-page-grid .gce-calendar .gce-next{
+	right:0;
+	position:absolute;
 }
 
 .gce-page-grid .gce-calendar .gce-month-title{ /* Month title */
-	display:inline-block;
-	width:80%;
+	text-align:center;
 }
 
 .gce-page-grid .gce-calendar th abbr{ /* Day letter abbreviation */
@@ -103,6 +107,8 @@
 
 .gce-widget-grid .gce-calendar .gce-caption{
 	text-align:center;
+	padding:bottom;
+	position:relative;
 }
 
 .gce-widget-grid .gce-calendar{ /* Main calendar table */
@@ -140,18 +146,20 @@
 .gce-widget-grid  .gce-calendar .gce-next,
 .gce-widget-grid  .gce-calendar .gce-prev{ /* Prev and next month links */
 	cursor:pointer;
-	display:inline-block;
-	width:5%;
-	white-space: nowrap;
 }
 
 .gce-widget-grid .gce-calendar .gce-prev{
-	float: left;
+	left:0;
+	position:absolute;
+}
+
+.gce-widget-grid .gce-calendar .gce-next{
+	right:0;
+	position:absolute;
 }
 
 .gce-widget-grid .gce-calendar .gce-month-title{ /* Month title in caption at top of table */
-	display:inline-block;
-	width:80%;
+	text-align:center;
 }
 
 .gce-widget-grid .gce-calendar th abbr{ /* Day name abbreviations */

--- a/google-calendar-events/includes/class-gce-display.php
+++ b/google-calendar-events/includes/class-gce-display.php
@@ -185,12 +185,12 @@ class GCE_Display {
 
 		// Add previous / next functionality
 		//If there are events to display in a previous month, add previous month link
-		$prev_key = ( $nav_prev ) ? '&laquo;' : '&nbsp;';
-		$prev = ( $nav_prev ) ? date( 'm-Y', mktime( 0, 0, 0, $month - 1, 1, $year ) ) : null;
+    $prev_key = ( $nav_prev ) ? '&laquo; ' . date("M", mktime(0, 0, 0, $month - 1)) . ' ' . $year : '&nbsp;';
+    $prev = ( $nav_prev ) ? date( 'm-Y', mktime( 0, 0, 0, $month - 1, 1, $year ) ) : null;
 
 		//If there are events to display in a future month, add next month link
-		$next_key = ( $nav_next ) ? '&raquo;' : '&nbsp;';
-		$next = ( $nav_next ) ? date( 'm-Y', mktime( 0, 0, 0, $month + 1, 1, $year ) ) : null;
+		$next_key = ( $nav_next ) ? date("M", mktime(0, 0, 0, $month + 1)) . ' ' . $year . ' &raquo;' : '&nbsp;';
+    $next = ( $nav_next ) ? date( 'm-Y', mktime( 0, 0, 0, $month + 1, 1, $year ) ) : null;
 
 		//Array of previous and next link stuff for use in gce_generate_calendar (below)
 		$pn = array( $prev_key => $prev, $next_key => $next );

--- a/google-calendar-events/includes/php-calendar.php
+++ b/google-calendar-events/includes/php-calendar.php
@@ -31,7 +31,7 @@ function gce_generate_calendar( $year, $month, $days = array(), $day_name_length
 		$day_names[$n]['initial'] = $wp_locale->get_weekday_initial( date_i18n( 'l', $t, true ) );
 	}
 
-	list( $month, $year, $month_name, $weekday ) = explode( ',', date_i18n( 'm, Y, F, w', $first_of_month ) );
+	list( $month, $year, $month_name, $weekday ) = explode( ',', date_i18n( 'm,Y,F,w', $first_of_month ) );
 	$weekday = ( $weekday + 7 - $first_day ) % 7; #adjust for $first_day
 	$title = esc_html( $month_name ) . '&nbsp;' . $year;  #note that some locales don't capitalize month and day names
 
@@ -40,19 +40,11 @@ function gce_generate_calendar( $year, $month, $days = array(), $day_name_length
 	list( $n, $nl ) = each( $pn ); #previous and next links, if applicable
 	
 	if ( $p ) {
-		if( $widget ) {
-			$p = '<span class="gce-prev">' . ( ( $pl ) ? ( '<a class="gce-change-month" title="Previous month" name="' . $pl . '">' . $p . '</a>' ) : $p ) . '</span>&nbsp;';
-		} else {
-			$p = '<span class="gce-prev">' . ( ( $pl ) ? ( '<a class="gce-change-month" title="Previous month" name="' . $pl . '">' . $p . ' Back</a>' ) : $p ) . '</span>&nbsp;';
-		}
+		$p = '<span class="gce-prev">' . ( ( $pl ) ? ( '<a class="gce-change-month" title="Previous month" name="' . $pl . '">' . $p . '</a>' ) : $p ) . '</span>';
 	}
 	
 	if ( $n ) {
-		if( $widget ) {
-			$n = '&nbsp;<span class="gce-next">' . ( ( $nl ) ? ( '<a class="gce-change-month" title="Next month" name="' . $nl . '">' . $n . '</a>' ) : $n ) . '</span>';
-		} else {
-			$n = '&nbsp;<span class="gce-next">' . ( ( $nl ) ? ( '<a class="gce-change-month" title="Next month" name="' . $nl . '">Next ' . $n . '</a>' ) : $n ) . '</span>';
-		}
+		$n = '<span class="gce-next">' . ( ( $nl ) ? ( '<a class="gce-change-month" title="Next month" name="' . $nl . '">' . $n . '</a>' ) : $n ) . '</span>';
 	}
 	
 	$calendar = '<table class="gce-calendar">' . "\n" . '<caption class="gce-caption">' . $p . '<span class="gce-month-title">' . ( ( $month_href ) ? ( '<a href="' . esc_attr( $month_href ) . '">' . $title . '</a>' ) : $title ) . '</span>' . $n . "</caption>\n<tr>";


### PR DESCRIPTION
Now the grid and widget look like this:
![screenshot 2014-09-19 13 15 18](https://cloud.githubusercontent.com/assets/2042219/4339175/933615da-4020-11e4-8029-f62024e55a87.png)

Also cleaned up control alignment and padding css for grid and widget views.
