### PR TITLE
Corrects nav parent collapse

### DIFF
--- a/google-calendar-events/css/gce-style.css
+++ b/google-calendar-events/css/gce-style.css
@@ -190,6 +190,7 @@
 	width: 100%;
 	text-align: center;
 	clear: both;
+	overflow: hidden;
 }
 
 .gce-next,


### PR DESCRIPTION
In list style, since back and next are the only 2 children of
gce-navbar, and they both float, the parent div collapses. This corrects
that, and stops the list from starting to render in the same space.
